### PR TITLE
strong-name assembly

### DIFF
--- a/PasswordProtectedChecker/PasswordProtectedChecker.csproj
+++ b/PasswordProtectedChecker/PasswordProtectedChecker.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>PasswordProtectedChecker.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <PackageReleaseNotes>- Updated nuget packages</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
@@ -14,11 +14,13 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>password zip outlook msg eml powerpoint word excel</PackageTags>
     <LangVersion>latest</LangVersion>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>PasswordChecker.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MsgReader" Version="6.0.3" />
-    <PackageReference Include="OpenMcdf" Version="3.0.2" />
+    <PackageReference Include="MsgReader" Version="6.0.5" />
+    <PackageReference Include="OpenMcdf" Version="3.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
 


### PR DESCRIPTION
@Sicos1977 please have a look: I've updated the packages to match what's in OfficeExtractor and made the assembly strong-named.
Please add snk file such that we can then proceed in the OfficeExtractor (I will create another, feature-based PR soon).

Best,
Christian